### PR TITLE
Refactor `Streamer`: `stream()` renamed to `_stream()`, and new `stream()` method takes a `Model` object

### DIFF
--- a/labnewt/_vof/_distribute_Mex.py
+++ b/labnewt/_vof/_distribute_Mex.py
@@ -75,6 +75,6 @@ def _distribute_Mex(
 
     Mqi = np.empty_like(Mqo)
 
-    Streamer().stream(Mqi, Mqo, s)
+    Streamer()._stream(Mqi, Mqo, s)
 
     return M_star + np.sum(Mqi, axis=0) + M_ex_neg - M_ex_pos

--- a/labnewt/model.py
+++ b/labnewt/model.py
@@ -131,7 +131,7 @@ class Model:
         self.macros.forcing(self)
 
         # Stream step
-        self.streamer.stream(self.fi, self.fo, self.stencil)
+        self.streamer.stream(self)
 
         # Apply boundary conditions.
         for bc in self.boundary_conditions:
@@ -364,7 +364,7 @@ class FreeSurfaceModel(Model):
             self.macros.forcing(self)
 
             # Stream step
-            self.streamer.stream(self.fi, self.fo, self.stencil)
+            self.streamer.stream(self)
 
             # Apply boundary conditions.
             self.fsbc.apply(self)
@@ -398,7 +398,7 @@ class FreeSurfaceModel(Model):
         self.macros.forcing(self)
 
         # Stream step
-        self.streamer.stream(self.fi, self.fo, self.stencil)
+        self.streamer.stream(self)
 
         # Apply boundary conditions.
         self.fsbc.apply(self)

--- a/labnewt/streamer.py
+++ b/labnewt/streamer.py
@@ -6,7 +6,26 @@ from .stencil import Stencil
 
 
 class Streamer:
-    def stream(
+    def stream(self, model):
+        """
+        Streams particles in `model.fo` to `model.fi`.
+
+            fi[q, y, x] = fo[q, y - s.ey[q], x - s.ex[q]]
+
+        Modifies `model.fi` in place.
+        `model.fo` is read-only and remains unchanged.
+
+        Parameters
+        ----------
+        model : Model or FreeSurfaceModel
+
+        Returns
+        -------
+        None
+        """
+        self._stream(model.fi, model.fo, model.stencil)
+
+    def _stream(
         self, fi: NDArray[np.float64], fo: NDArray[np.float64], s: Stencil
     ) -> None:
         """

--- a/tests/unit/test_streamer.py
+++ b/tests/unit/test_streamer.py
@@ -10,7 +10,7 @@ def test_streamer_with_d2q9_stencil():
     fo = 1.0 * i + 0.1 * j + 0.01 * k
     fo0 = np.copy(fo)
     fi = np.empty_like(fo)
-    streamer.stream(fi, fo, s)
+    streamer._stream(fi, fo, s)
 
     # fo should not be changed
     assert np.allclose(fo, fo0, atol=1.0e-12)


### PR DESCRIPTION
Proposed changes
--------------------
- Modify `Streamer` public interface so that `stream()` method takes a `model` object.
- Rename old `stream()` method to `_stream()`, and keep for use in `VolumeOfFluid` mass exchange implementation.
- Update `Model` `run()` method to use the new `Streamer` API.

Testing
--------
- [x] All unit tests pass locally
- [x] All integrations tests pass locally
- [x] All formatting checks pass locally