### PR TITLE
Update `VolumeOfFluid` public interface

### DIFF
--- a/labnewt/model.py
+++ b/labnewt/model.py
@@ -337,7 +337,7 @@ class FreeSurfaceModel(Model):
     def _initialise(self, do_mei=False):
         """Initialise model."""
         self._initialise_feq2()
-        self.vof.initialise(self.r)
+        self.vof.initialise(self)
 
         # Mei's method: timestep but without evolving velocity
         # until fi stabilises.
@@ -411,7 +411,7 @@ class FreeSurfaceModel(Model):
         self.macros.velocity_y(self)
 
         # Update free surface
-        self.vof.step(self.fo, self.r, self.stencil)
+        self.vof.update(self)
 
         # Update time
         self.clock += self.dt


### PR DESCRIPTION
Proposed changes
---------------------
- Update the `VolumeOfFluid` public interface:
 - `initialise()` to take a `Model` object instead of a two-dimensional numpy array;
 - `step()` to be renamed to `update()` and to take a `Model` object instead of several arrays.
- Update `FreeSurfaceModel` to use the new `VolumeOfFluid` public interface.

Motivation
------------
- Allows changes to the internals of `VolumeOfFluid` without changing the public interface.
- Makes `VolumeOfFluid` public interface consistent with other `labnewt` class interfaces.

Testing
--------
- [x] All unit tests pass locally.
- [x] All integration tests pass locally.
- [x] All formatting checks pass locally.